### PR TITLE
Don't bundle debug symbols within the app

### DIFF
--- a/io.qt.QtCreator.yaml
+++ b/io.qt.QtCreator.yaml
@@ -46,6 +46,9 @@ modules:
         tag: '5.63'
   - name: clang
     buildsystem: cmake-ninja
+    build-options:
+      cflags: -g1
+      cxxflags: -g1
     subdir: llvm
     builddir: true
     config-opts:

--- a/io.qt.QtCreator.yaml
+++ b/io.qt.QtCreator.yaml
@@ -20,7 +20,6 @@ finish-args:
   - --allow=devel
 build-options:
   append-ld-library-path: /app/lib
-  no-debuginfo: true
 modules:
   - name: bluez
     buildsystem: autotools


### PR DESCRIPTION
This will split debug symbols from shared libraries to separate .Debug extension. It should save significant space. This is default flatpak behavior while the current one was introduced by https://github.com/flathub/io.qt.QtCreator/commit/d6859b9d29362666e59936428adf581c8b00a8bb without explanation.