### PR TITLE
Do not remove clangd

### DIFF
--- a/io.qt.QtCreator.yaml
+++ b/io.qt.QtCreator.yaml
@@ -68,8 +68,8 @@ modules:
     sources:
       - type: git
         url: https://code.qt.io/clang/llvm-project
-        branch: release_110-based
-        commit: e43a39a3ed2ec0a05638956cdebfd2f7cf164692
+        branch: release_140-based
+        commit: a8ed6c28965138fa1f2449e4ce3e9f391380d17b
   - name: clazy
     buildsystem: cmake-ninja
     config-opts:

--- a/io.qt.QtCreator.yaml
+++ b/io.qt.QtCreator.yaml
@@ -912,7 +912,6 @@ cleanup:
   - /bin/clang-check
   - /bin/clang-cl
   - /bin/clang-cpp
-  - /bin/clangd
   - /bin/clang-doc
   - /bin/clang-extdef-mapping
   - /bin/clang-format


### PR DESCRIPTION
clangd can be used by QtCreator as backend for the C/C++ code model.