### PR TITLE
Switch to prebuilt Qt Creator 19.0.2 binary; freedesktop runtime; llvm22 extension

### DIFF
--- a/io.qt.QtCreator.yaml
+++ b/io.qt.QtCreator.yaml
@@ -1,13 +1,17 @@
 app-id: io.qt.QtCreator
-runtime: org.kde.Sdk
-runtime-version: '6.10'
-base: io.qt.qtwebengine.BaseApp
-base-version: '6.10'
-sdk: org.kde.Sdk
+runtime: org.freedesktop.Sdk
+runtime-version: '25.08'
+sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.llvm21
   - org.freedesktop.Sdk.Extension.node22
   - org.freedesktop.Sdk.Extension.openjdk
+add-extensions:
+  org.freedesktop.Sdk.Extension.llvm22:
+    version: '25.08'
+    directory: lib/sdk/llvm22
+    add-ld-path: lib
+    autodelete: false
+    no-autodownload: false
 command: qtcreator
 rename-desktop-file: org.qt-project.qtcreator.desktop
 rename-appdata-file: org.qt-project.qtcreator.appdata.xml
@@ -22,57 +26,46 @@ finish-args:
   - --filesystem=/sys
   - --device=dri
   - --allow=devel
-  - --env=QTWEBENGINEPROCESS_PATH=/app/bin/QtWebEngineProcess
   - --env=VCPKG_ROOT=$HOME/.local/share/vcpkg
-  - --env=LLVM_INSTALL_DIR=/app
-  - --env=PATH=/app/bin:/usr/bin:/usr/lib/sdk/node22/bin
+  - --env=LLVM_INSTALL_DIR=/app/lib/sdk/llvm22
+  - --env=PATH=/app/bin:/app/libexec/qtcreator/clang/bin:/app/lib/sdk/llvm22/bin:/usr/bin:/usr/lib/sdk/node22/bin
 build-options:
-  prepend-path: /usr/lib/sdk/llvm21/bin
-  prepend-ld-library-path: /usr/lib/sdk/llvm21/lib
   arch:
     aarch64:
       prepend-pkg-config-path: /app/lib/aarch64-linux-gnu/pkgconfig
     x86_64:
       prepend-pkg-config-path: /app/lib/x86_64-linux-gnu/pkgconfig
 modules:
+  - krb5.yaml
   - name: qt-creator
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DSHOW_BUILD_DATE=ON
-      - -DWITH_QMLDESIGNER=OFF
-      - -DCLANGTOOLING_LINK_CLANG_DYLIB=ON
-      - -DWITH_ONLINE_DOCS=ON
-      - -DBUILD_DEVELOPER_DOCS=OFF
-      - -DBUILD_DOCS_BY_DEFAULT=OFF
-      - -DBUILD_EXECUTABLE_CMDBRIDGE=OFF
-      - -Wno-dev
-    sources:
-      - type: git
-        url: https://github.com/qt-creator/qt-creator.git
-        tag: v19.0.2
-        commit: 41c25c247e950bb4b462948281d366af029f5a8e
-        x-checker-data:
-          type: anitya
-          project-id: 4136
-          tag-template: v$version
-          stable-only: true
-    post-install:
-      - cp -a /usr/lib/sdk/llvm21/* /app
-      - install -d /app/extensions
-  - name: docs
     buildsystem: simple
     sources:
       - type: archive
-        url: https://github.com/qt-creator/qt-creator/releases/download/v19.0.2/qtcreator-linux-x64-19.0.2.7z
-        sha256: e4035aa9998c27a0f886360cd933ae42288d8c7776aaa60f537c2e01b3425b9c
+        only-arches:
+          - x86_64
+        url: https://download.qt.io/official_releases/qtcreator/19.0/19.0.2/installer_source/linux_x64/qtcreator.7z
+        sha256: da51f6ab750182b73b093cc0b5efe01cda6c9478a4361904e85619b58535ad09
         strip-components: 0
         x-checker-data:
           type: anitya
           project-id: 4136
-          url-template: https://github.com/qt-creator/qt-creator/releases/download/v$version/qtcreator-linux-x64-$version.7z
+          url-template: https://download.qt.io/official_releases/qtcreator/$version_major.$version_minor/$version/installer_source/linux_x64/qtcreator.7z
+          stable-only: true
+      - type: archive
+        only-arches:
+          - aarch64
+        url: https://download.qt.io/official_releases/qtcreator/19.0/19.0.2/installer_source/linux_arm64/qtcreator.7z
+        sha256: cddd210c7e7258a19bea986308db689cdc6225564ae87ec49c529842ad630924
+        strip-components: 0
+        x-checker-data:
+          type: anitya
+          project-id: 4136
+          url-template: https://download.qt.io/official_releases/qtcreator/$version_major.$version_minor/$version/installer_source/linux_arm64/qtcreator.7z
           stable-only: true
     build-commands:
-      - cp -r share/doc/qtcreator $FLATPAK_DEST/share/doc
+      - cp -a bin lib libexec share "$FLATPAK_DEST/"
+      - install -d "$FLATPAK_DEST/lib/sdk/llvm22"
+      - install -d "$FLATPAK_DEST/extensions"
   - mold.yaml
   - python3-conan.yaml
   - python3-gcovr.yaml

--- a/krb5.yaml
+++ b/krb5.yaml
@@ -1,0 +1,26 @@
+name: krb5
+buildsystem: autotools
+subdir: src
+config-opts:
+  - --disable-static
+  - --disable-rpath
+  - --without-libedit
+  - --without-readline
+  - --without-system-verto
+cleanup:
+  - /bin
+  - /sbin
+  - /share/doc
+  - /share/examples
+  - /share/man
+  - /include
+  - /lib/pkgconfig
+sources:
+  - type: archive
+    url: https://kerberos.org/dist/krb5/1.22/krb5-1.22.2.tar.gz
+    sha256: 3243ffbc8ea4d4ac22ddc7dd2a1dc54c57874c40648b60ff97009763554eaf13
+    x-checker-data:
+      type: anitya
+      project-id: 3909
+      url-template: https://kerberos.org/dist/krb5/$version_major.$version_minor/krb5-$version.tar.gz
+      stable-only: true

--- a/python3-conan.yaml
+++ b/python3-conan.yaml
@@ -80,7 +80,7 @@ sources:
       name: patch-ng
       type: pypi
       versions:
-        - <: 1.19
+        - <: '1.19'
   - type: file
     url: https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl
     sha256: 4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274
@@ -110,5 +110,5 @@ sources:
       packagetype: bdist_wheel
       type: pypi
       versions:
-        - <: 3.0
+        - <: '3.0'
 


### PR DESCRIPTION
## Summary
- **Stop building Qt Creator from source.** Extract the official open-source `installer_source/qtcreator.7z` from download.qt.io instead — same payload that ships inside `qt-creator-opensource-linux-x86_64-19.0.2.run`. The archive carries its own bundled Qt 6.10.3 (plus Qbs and the IDE's clang tooling), so KDE runtime updates can no longer break Qt Creator's private-API linkage.
- **Bump to 19.0.2** and **add aarch64** (qt.io publishes `linux_arm64` installer_source archives from 19.0.2).
- **Runtime: `org.kde.Sdk//6.10` → `org.freedesktop.Sdk//25.08`** — the runtime's Qt was only needed by the source build.
- **LLVM: `Sdk.Extension.llvm22` is now mounted via `add-extensions`** at `/app/lib/sdk/llvm22` rather than `cp -a`'d into `/app`. Saves ~700 MB per install; the extension is deduplicated across all Flatpaks that consume it. `PATH` order: `/app/bin` → QtC bundled clang tooling → llvm22, so QtC's matched `clangd`/`clang-format`/`clang-tidy`/`clazy-standalone` win while llvm22 provides `clang`/`clang++`/`lld`.
- **Drop `io.qt.qtwebengine.BaseApp`** — keeping it would reintroduce Qt-version drift between bundled Qt and BaseApp WebEngine. Help viewer falls back to QTextBrowser.
- **Drop separate `docs` module** — binary already includes `share/doc/qtcreator`.
- **New `krb5` module** — `org.freedesktop.Sdk` doesn't ship Kerberos; `libQt6Network.so` and `qtcreator` need `libgssapi_krb5.so.2` (HTTP Negotiate auth).
- Drive-by: quote two version-pin bounds in `python3-conan.yaml` so YAML doesn't parse `1.19` / `3.0` as floats.

## Test plan
- [x] `flatpak-builder --user --install-deps-from=flathub --force-clean --ccache builddir io.qt.QtCreator.yaml` succeeds end-to-end (verified locally).
- [x] `flatpak-builder --run --env=QT_QPA_PLATFORM=offscreen builddir … qtcreator -version` reports Qt Creator 19.0.2 / Qt 6.10.3, enumerates all plugins, no license-check prompt.
- [x] `ldd /app/bin/qtcreator` resolves `libgssapi_krb5.so.2` to `/app/lib/libgssapi_krb5.so.2`.
- [x] `which clangd clang-format clang-tidy clazy-standalone` resolves to `/app/libexec/qtcreator/clang/bin` (QtC bundle precedes llvm22).
- [ ] Verify on Flathub builder for aarch64.
- [ ] Verify Help mode opens (uses QTextBrowser fallback now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)